### PR TITLE
Fixes #GPCACHEEHCACHE-5

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -13,6 +13,8 @@ grails.project.dependency.resolution = {
 
 	dependencies {
 		compile 'net.sf.ehcache:ehcache-core:2.4.6'
+
+        test 'org.codehaus.gpars:gpars:1.0.0'
 	}
 
 	plugins {

--- a/test/unit/grails/plugin/cache/ehcache/EhcacheCacheManagerTests.groovy
+++ b/test/unit/grails/plugin/cache/ehcache/EhcacheCacheManagerTests.groovy
@@ -1,0 +1,63 @@
+package grails.plugin.cache.ehcache
+
+import grails.test.GrailsUnitTestCase
+import grails.test.mixin.TestFor
+import groovyx.gpars.GParsPool
+import net.sf.ehcache.CacheManager
+import org.junit.Before
+
+/**
+ * @author Andrew Walters
+ */
+class EhcacheCacheManagerTests extends GrailsUnitTestCase {
+
+    protected GrailsEhcacheCacheManager manager
+
+    @Before
+    void before() {
+        manager = new GrailsEhcacheCacheManager()
+        manager.cacheManager = CacheManager.create()
+    }
+
+    void "test cache creation serial access"() {
+        (0..10).each {
+            manager.getCache("testCache")
+        }
+    }
+
+    /**
+     * As a parallel access isn't guaranteed to result in traversing the code at the same time, loop a number
+     * of times to try and cause the simultaneous access to getCache()
+     */
+    void "test cache creation parallel access"() {
+        assertFalse(manager.cacheExists("testCache"))
+
+        10.times {
+            println "Trying to get a failure x ${it + 1}"
+
+            GParsPool.withPool {
+                (0..4).everyParallel {
+                    manager.getCache("testCache") != null
+                }
+
+                manager.destroyCache("testCache")
+            }
+        }
+    }
+
+    void "test cache get parallel access"() {
+        manager.getCache("testCache")
+
+        assertTrue(manager.cacheExists("testCache"))
+
+        10.times {
+            println "Trying to get a failure x ${it + 1}"
+
+                GParsPool.withPool {
+                (0..10).eachParallel {
+                    assertNotNull(manager.getCache("testCache"))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Jira Issue (http://jira.grails.org/browse/GPCACHEEHCACHE-5) - Parallel access to getCache() can result in 'cache already exists' exception)
