### PR TITLE
Updated documentation with details on rmiUrl

### DIFF
--- a/src/docs/guide/usage/dsl.gdoc
+++ b/src/docs/guide/usage/dsl.gdoc
@@ -525,3 +525,20 @@ and this XML in development:
 
 </ehcache>
 {code}
+
+
+h5. Manual Peer Discovery
+
+In some cases it may be necessary to specify peers directly instead of via Multicast (i.e. Amazon EC2), To do this you must specify your rmiUrls via the following dsl:
+
+{code}
+   cacheManagerPeerProviderFactory {
+      env 'production'
+      factoryType 'rmi'
+      
+      rmiUrl '//server2:40001'
+      rmiUrl '//server2:40001'
+   }
+{code}
+
+Note: This varies from the standard xml DSL for ehcache (don't need rmiUrls pipe seperated string). The plugin is smart enough to automatically change @peerDiscovery@ to 'manual' if rmiUrl is specified.


### PR DESCRIPTION
It appears that you cannot pass  `rmiUrls` in the `cacheManagerPeerProviderFactory` definition. Instead you must specify using multiple calls to `rmiUrl` like so:

``` groovy
cacheManagerPeerProviderFactory {
  factoryType 'rmi'
  rmiUrl '//server1:40001'
  rmiUrl '//server2:40001'
}
```

This updates the documentation with regards to distributed DSL.
