### PR TITLE
added rmiUrl fix for 1.0.3

### DIFF
--- a/src/groovy/grails/plugin/cache/ehcache/EhcacheConfigBuilder.groovy
+++ b/src/groovy/grails/plugin/cache/ehcache/EhcacheConfigBuilder.groovy
@@ -596,7 +596,7 @@ class EhcacheConfigBuilder extends BuilderSupport {
 	protected void appendCacheManagerPeerProviderFactoryNode(StringBuilder xml, Map data,
 			String delimiter, String className) {
 
-		String properties = joinProperties(data, delimiter, ['className', 'factoryType', 'rmiUrls'])
+		String properties = joinProperties(data, delimiter, ['className', 'factoryType'])
 		appendSimpleNodeWithProperties xml, 'cacheManagerPeerProviderFactory', className, properties, delimiter
 	}
 


### PR DESCRIPTION
Removing 'rmiUrls' allows rmiUrl property to be picked up in config as intended for manual peer declarations to work properly. Otherwise the rmiUrl property is ignored and manual peer discovery configuration does not work.