### PR TITLE
Remove diskStorePathManager instance before reinitialisation cache

### DIFF
--- a/src/main/java/grails/plugin/cache/ehcache/GrailsEhCacheManagerFactoryBean.java
+++ b/src/main/java/grails/plugin/cache/ehcache/GrailsEhCacheManagerFactoryBean.java
@@ -162,19 +162,19 @@ public class GrailsEhCacheManagerFactoryBean implements FactoryBean<CacheManager
 
 			status = Status.STATUS_UNINITIALISED;
 
-//            Field diskStorePathManager = ReflectionUtils.findField(CacheManager.class, "diskStorePathManager", net.sf.ehcache.DiskStorePathManager.class);
-//			ReflectionUtils.makeAccessible(diskStorePathManager);
-//			ReflectionUtils.setField(diskStorePathManager, this, null);
+            Field diskStorePathManager = ReflectionUtils.findField(CacheManager.class, "diskStorePathManager", net.sf.ehcache.DiskStorePathManager.class);
+			ReflectionUtils.makeAccessible(diskStorePathManager);
+     		ReflectionUtils.setField(diskStorePathManager, this, null);
 
-//			@SuppressWarnings("unchecked")
-//			Map<CacheManager, String> CACHE_MANAGERS_REVERSE_MAP = (Map<CacheManager, String>)getStaticValue(findField("CACHE_MANAGERS_REVERSE_MAP"));
-//			final String name = CACHE_MANAGERS_REVERSE_MAP.remove(this);
-//			@SuppressWarnings("unchecked")
-//			Map<String, CacheManager> CACHE_MANAGERS_MAP = (Map<String, CacheManager>)getStaticValue(findField("CACHE_MANAGERS_MAP"));
-//			CACHE_MANAGERS_MAP.remove(name);
+			@SuppressWarnings("unchecked")
+			Map<CacheManager, String> CACHE_MANAGERS_REVERSE_MAP = (Map<CacheManager, String>)getStaticValue(findField("CACHE_MANAGERS_REVERSE_MAP"));
+			final String name = CACHE_MANAGERS_REVERSE_MAP.remove(this);
+			@SuppressWarnings("unchecked")
+			Map<String, CacheManager> CACHE_MANAGERS_MAP = (Map<String, CacheManager>)getStaticValue(findField("CACHE_MANAGERS_MAP"));
+			CACHE_MANAGERS_MAP.remove(name);
 
 			// remove since it's going to be re-added
-//			ALL_CACHE_MANAGERS.remove(this);
+			ALL_CACHE_MANAGERS.remove(this);
 
 			init(null, null, null, location.getInputStream());
 		}


### PR DESCRIPTION
@jeffbrown i'm having some trouble with this https://github.com/grails-plugins/grails-cache-ehcache/commit/a1a99bd182e3e1cb2c351fd96d3872d273f26dcb.
When ApplicationContext tries to reload the cache, CacheManager.java throws IllegalStateException because diskStorePathManager is not null.

CacheManager.java lines 523

private void reinitialisationCheck() throws IllegalStateException {
        if(this.diskStorePathManager != null || this.ehcaches.size() != 0 || this.status.equals(Status.STATUS_SHUTDOWN)) {
            throw new IllegalStateException("Attempt to reinitialise the CacheManager");
        }
    }
When I uncomment these lines, the app can load successfully (See orkonano@4212d57)

I'v been navigating the CacheManager code to find other way to do it but unfortunately I couldn't.

Is it possible to rollback your commit?

Thanks

Mariano Kfuri
