### PR TITLE
Updating version number to match build.gradle

### DIFF
--- a/src/main/groovy/cacheehcache/CacheEhcacheGrailsPlugin.groovy
+++ b/src/main/groovy/cacheehcache/CacheEhcacheGrailsPlugin.groovy
@@ -15,7 +15,7 @@ class CacheEhcacheGrailsPlugin extends Plugin {
         "grails-app/views/error.gsp"
     ]
 
-    def version = '2.0.0.BUILD-SNAPSHOT'
+    def version = '3.0.0.BUILD-SNAPSHOT'
 
     def title = "Cache Ehcache" // Headline display name of the plugin
     def author = "Jeff Brown"


### PR DESCRIPTION
When the version number was updated in build.gradle, the CacheEhcacheGrailsPlugin was missed.